### PR TITLE
fixed hydra.utils.instantiate

### DIFF
--- a/conf/train/default_train.yaml
+++ b/conf/train/default_train.yaml
@@ -8,6 +8,7 @@ model_name: default_name  # used to name the directory in which model's checkpoi
 
 # pl_trainer
 pl_trainer:
+  _target_: pytorch_lightning.Trainer
   gpus: 1
   accumulate_grad_batches: 4
   gradient_clip_val: 10.0
@@ -20,6 +21,7 @@ pl_trainer:
 # early stopping callback
 # "early_stopping_callback: null" will disable early stopping
 early_stopping_callback:
+  _target_: pytorch_lightning.callbacks.EarlyStopping
   monitor: val_loss
   mode: min
   patience: 50
@@ -27,6 +29,7 @@ early_stopping_callback:
 # model_checkpoint_callback
 # "model_checkpoint_callback: null" will disable model checkpointing
 model_checkpoint_callback:
+  _target_: pytorch_lightning.callbacks.ModelCheckpoint
   monitor: val_loss
   mode: min
   verbose: True

--- a/src/train.py
+++ b/src/train.py
@@ -2,6 +2,7 @@ import omegaconf
 import hydra
 
 import pytorch_lightning as pl
+from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 
 from src.pl_data_modules import BasePLDataModule
@@ -23,15 +24,15 @@ def train(conf: omegaconf.DictConfig) -> None:
     callbacks_store = []
 
     if conf.train.early_stopping_callback is not None:
-        early_stopping_callback = hydra.utils.instantiate(conf.train.early_stopping_callback)
+        early_stopping_callback: EarlyStopping = hydra.utils.instantiate(conf.train.early_stopping_callback)
         callbacks_store.append(early_stopping_callback)
 
     if conf.train.model_checkpoint_callback is not None:
-        model_checkpoint_callback = hydra.utils.instantiate(conf.train.early_stopping_callback)
+        model_checkpoint_callback: ModelCheckpoint = hydra.utils.instantiate(conf.train.early_stopping_callback)
         callbacks_store.append(model_checkpoint_callback)
 
     # trainer
-    trainer = hydra.utils.instantiate(conf.train.pl_trainer, callbacks=callbacks_store)
+    trainer: Trainer = hydra.utils.instantiate(conf.train.pl_trainer, callbacks=callbacks_store)
 
     # module fit
     trainer.fit(pl_module, datamodule=pl_data_module)


### PR DESCRIPTION
Hi @edobobo thank you again for your great work.
I have used the actual version of the template and immediately I got an error which is the following:
`
Input config does not have a '_target_' field
`
The pull request fix that issue.
The problem here is with the auto instantiation of the object, in the configuration file the _target_ entry is missing, without that entry for py-lightning is impossible to understand which object has to instantiate.
